### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+inst/js/* linguist-vendored


### PR DESCRIPTION
Cf https://github.com/github/linguist#overrides with this PR the JS code that was not written as part of this repo will be correctly marked as vendored and this way the repo will be classified as R repo 🎊 